### PR TITLE
Updating the script to generate a stronger key pair by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # Git_SSH-Account_Switch
+
 A CLI tool can switch ssh account to your current shell. You will easily switch to your git account & ssh key when using the server, and using your account to manipulate the project on the server.
 
 ## Installation
+
 ```shell
 $ bash ./setup.sh
 ```
+
 it will add some code in your `profile` & `$logout_profile`, and setup `git-acc` & `.gitacc` on the `$HOME`. \
 file:
 > git-acc.sh -> $HOME/.git-acc, `git-acc` function.\
 > .gitacc   -> $HOME/.gitacc, save info. that regist on `git-acc`.
+
 ## Control
+
 ```shell
         +---------------+
         |    git-acc    |
@@ -33,38 +38,49 @@ EXAMPLES
 ```
 
 ### SWITCH ACCOUNT
+
 When you want to use the account that you have already added it, you can type:
+
 ```shell
 $ git-acc <tab>
 ```
+
 Then it will come out the current account that registers in the `git-acc` to let you choose, e.g.
+
 ```shell
 $ git-acc <tab>
 tw-yshuang cool-name ...
 ```
 
 ### ADD
+
 ```shell
 $ git-acc -add
     or
 $ git-acc --add_account
 ```
+
 It will ask you to type:
+
 ```shell
 Enter your git user name: <acc_name>
 Enter your git user mail: <acc_mail>
 ```
-After that, `git-acc` will generate `id_rsa_<acc_name>`, `id_rsa_<acc_name>.pub` in the `$HOME/.ssh`. \
+
+After that, `git-acc` will generate `id_ed25519_<acc_name>`, `id_ed25519_<acc_name>.pub` in the `$HOME/.ssh`. \
 Next, you can type `$ git-acc <acc_name>`, to login your account.\
 NOTE: You also can overwrite your account.
 
 ### REMOVE
+
 ```shell
 $ git-acc -rm
     or
 $ git-acc --remove_account
 ```
+
 It will ask you to type:
+
 ```shell
 Enter the git user name you want to remove: <acc_name>
 ```

--- a/git-acc.sh
+++ b/git-acc.sh
@@ -69,7 +69,7 @@ function git-acc(){
     unset users_info
   }
 
-  local ssh_key_locate="$HOME/.ssh/id_rsa_"  # "./id_rsa_"
+  local ssh_key_locate="$HOME/.ssh/id_ed25519_"  # "./id_ed25519_"
   local gitacc_locate="$HOME/.gitacc" # "./.gitacc"
   local GIT_ACC_ARG=()
   local GIT_ACC=()    # git account to 
@@ -129,7 +129,7 @@ function git-acc(){
         done
 
         # generate ssh-key
-        ssh-keygen -t rsa -C "$user_mail" -f "$ssh_key_locate$user_name"
+        ssh-keygen -t ed25519 -C "$user_mail" -f "$ssh_key_locate$user_name"
         if [ $overWrite = 0 ]; then # if recover is not happen, then write it to the $gitacc_locate, else nothing change.
           echo "[$user_name]\n\tname = $user_name\n\temail = $user_mail\n\tprivate_key = $ssh_key_locate$user_name\n\tpublic_key = $ssh_key_locate$user_name.pub" >> "$gitacc_locate"
         fi

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ case $SHELL in
     logout_profile=~/.bash_logout
     ;;
     * )
-    Echo_Color r "Unknow shell, need to manually add pyenv config on your shell profile!!"
+    Echo_Color r "Unknown shell, need to manually add pyenv config on your shell profile!!"
     ;;
 esac
 


### PR DESCRIPTION
Github is deprecating the usage of insecure rsa formats in the next month. Instead of generating an older format this is generating the newer one by default and adding minor documentation updates. 
https://github.blog/2021-09-01-improving-git-protocol-security-github/